### PR TITLE
Add installer and uninstaller for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Clone the repository
 ```bash
 $ git clone https://github.com/confident-hate/seedr-cli.git
 $ cd seedr-cli
-$ pip install -r requirements.txt 
+$ pip install -r requirements.txt
+$ sudo bash install.sh --install
 ```
+To uninstall seedr, execute the command `seedr --uninstall`
+
 Also you need to install firefox web browser on your machine.
 
 ## Features
@@ -23,11 +26,6 @@ Also you need to install firefox web browser on your machine.
   * Search torrents via RARBG
   
 ## Usage
-
-You should add this in your ~/.zshrc file:
-```
-alias seedr='python3 /path/to/seedr-cli/main.py
-```
 
 ```
 $ seedr -h

--- a/bin/seedr
+++ b/bin/seedr
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$1" = "--uninstall" ]; then
+    sudo bash /usr/share/seedr-cli/install.sh --uninstall
+
+else
+    python3 /usr/share/seedr-cli/main.py "$@"
+fi 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+if [ "$(id -u)" != "0" ]; then
+    echo "Run it as root"
+	echo
+	echo "usage: sudo bash install.sh --install | --uninstall"
+
+else
+	if [ "$1" = "--install" ] ; then
+		if [ ! -f /usr/bin/geckodriver ] && [ ! -f /usr/local/bin/geckodriver ] ; then
+			echo "[!] Downloading and Installing geckodriver"
+			wget https://github.com/mozilla/geckodriver/releases/download/v0.28.0/geckodriver-v0.28.0-linux32.tar.gz -c -P /tmp/seedr-cli -q --show-progress || { echo "[-] Download failed ";exit 1;}
+			tar -xf /tmp/seedr-cli/geckodriver-v0.28.0-linux32.tar.gz -C /usr/bin || exit 1
+			chmod +x /usr/bin/geckodriver || exit 1
+			echo "[+] geckodriver installed successfully"
+		else
+			echo "[+] geckodriver is already installed"
+		fi
+
+		if [ ! -d /usr/share/seedr-cli ]; then
+			mkdir /usr/share/seedr-cli
+		fi
+
+		cp main.py rarbg.py mySelenium.py x1337.py install.sh /usr/share/seedr-cli || exit 1
+		cp bin/seedr /usr/bin || exit 1
+		chmod +x /usr/bin/seedr || exit 1
+		echo "[+] Seedr installed successfully"
+
+	elif [ "$1" = "--uninstall" ] ; then
+		if [ -d /usr/share/seedr-cli ] ; then
+			rm -r  /usr/share/seedr-cli
+		fi
+		if [ -e /usr/bin/seedr ] ; then
+			rm /usr/bin/seedr
+		fi
+		echo "[-_-] Seedr uninstalled successfully"
+	else
+		echo "usage: bash install.sh --install | --uninstall"
+	fi			
+fi 


### PR DESCRIPTION
Hi @confident-hate,

I really like this project and I have added an installer and uninstaller of seedr-cli for Linux.

Simply type `sudo bash install.sh --install` which will:
- Automatically download the gecko driver from its official source and install it if the driver is missing.
- Copy the files of seedr-cli in /usr/share/seedr-cli.
- Copy the bin of seedr in /usr/bin so you can type `seedr` to run the script.

After installation, you can uninstall with `seedr --uninstall` or `sudo bash install.sh --uninstall`

Thanks!